### PR TITLE
Add Python version check

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,5 +1,11 @@
 import os
 import asyncio
+import sys
+
+# Ensure we are running on a supported Python version.
+if not (sys.version_info.major == 3 and 8 <= sys.version_info.minor <= 12):
+    sys.exit("YouTube Music Bot requires Python 3.8–3.12.")
+
 import discord
 from discord.ext import commands
 import youtube_dl


### PR DESCRIPTION
## Summary
- check Python version early in `bot.py`

## Testing
- `python -m py_compile bot.py`
- `python bot.py` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_68427c7e11cc833291bc85f3f6baa147